### PR TITLE
fixed renderCardPreview ordering

### DIFF
--- a/src/main/java/spireCafe/ui/Dialog.java
+++ b/src/main/java/spireCafe/ui/Dialog.java
@@ -277,6 +277,8 @@ public class Dialog {
             }
             for (OptionButton button : optionList) {
                 button.render(sb);
+            }
+            for (OptionButton button : optionList) {
                 button.renderCardPreview(sb);
                 button.renderRelicPreview(sb);
             }


### PR DESCRIPTION
fixed a bug with the ordering of the cardPreview and the buttons that would cause it to render behind later buttons

from this
![image](https://github.com/user-attachments/assets/9f991fc8-ca81-476f-85ba-eea257fa3c1f)

to this
![image](https://github.com/user-attachments/assets/ffa1fcfa-4eb9-4462-92c2-cf0b2f7a406f)
