### PR TITLE
Packmistress patron

### DIFF
--- a/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
+++ b/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
@@ -1,6 +1,13 @@
 package spireCafe.interactables.patrons.packmistress;
 
-import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.curses.Clumsy;
+import com.megacrit.cardcrawl.cards.curses.Writhe;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.RelicLibrary;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndObtainEffect;
 import spireCafe.abstracts.AbstractCutscene;
 import spireCafe.abstracts.AbstractNPC;
 import spireCafe.util.cutsceneStrings.CutsceneStrings;
@@ -12,25 +19,41 @@ public class PackmistressCutscene extends AbstractCutscene {
     public static final String ID = makeID(PackmistressCutscene.class.getSimpleName());
     private static final CutsceneStrings cutsceneStrings = LocalizedCutsceneStrings.getCutsceneStrings(ID);
 
+    private final AbstractRelic relic1;
+    private final AbstractRelic relic2;
+    private final int maxHp;
+    private final AbstractCard curse;
+
     public PackmistressCutscene(AbstractNPC character) {
         super(character, cutsceneStrings);
+        this.relic1 = RelicLibrary.getRelic("anniv5:HandyHaversack");
+        this.relic2 = RelicLibrary.getRelic("anniv5:PMBoosterBox");
+        this.maxHp = (int)(AbstractDungeon.player.maxHealth * 0.2f);
+        this.curse = new Clumsy();
     }
 
     @Override
     protected void onClick() {
         if (dialogueIndex == 0) {
             nextDialogue();
-            this.dialog.addDialogOption(OPTIONS[0]).setOptionResult((i)->{
+        }
+        else if (dialogueIndex == 1) {
+            nextDialogue();
+            this.dialog.addDialogOption(OPTIONS[0].replace("{0}", this.relic1.name).replace("{1}", this.maxHp + ""), this.relic1).setOptionResult((i)->{
+                AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2), this.relic1);
+                AbstractDungeon.player.decreaseMaxHealth(this.maxHp);
                 character.alreadyPerformedTransaction = true;
-                goToDialogue(2);
-                character.blockingDialogueIndex = 0;
-                CardCrawlGame.sound.play("ATTACK_PIERCING_WAIL", 0f);
+                goToDialogue(3);
             });
-            this.dialog.addDialogOption(OPTIONS[1]).setOptionResult((i)-> goToDialogue(3));
+            this.dialog.addDialogOption(OPTIONS[1].replace("{0}", this.relic2.name), this.relic2).setOptionResult((i)->{
+                AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2), this.relic2);
+                AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(this.curse, (float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2)));
+                character.alreadyPerformedTransaction = true;
+                goToDialogue(3);
+            });
+            this.dialog.addDialogOption(OPTIONS[2]).setOptionResult((i)-> goToDialogue(4));
         } else if (dialogueIndex >= 2) {
             endCutscene();
-        } else {
-            nextDialogue();
         }
     }
 }

--- a/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
+++ b/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
@@ -1,0 +1,36 @@
+package spireCafe.interactables.patrons.packmistress;
+
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import spireCafe.abstracts.AbstractCutscene;
+import spireCafe.abstracts.AbstractNPC;
+import spireCafe.util.cutsceneStrings.CutsceneStrings;
+import spireCafe.util.cutsceneStrings.LocalizedCutsceneStrings;
+
+import static spireCafe.Anniv7Mod.makeID;
+
+public class PackmistressCutscene extends AbstractCutscene {
+    public static final String ID = makeID(PackmistressCutscene.class.getSimpleName());
+    private static final CutsceneStrings cutsceneStrings = LocalizedCutsceneStrings.getCutsceneStrings(ID);
+
+    public PackmistressCutscene(AbstractNPC character) {
+        super(character, cutsceneStrings);
+    }
+
+    @Override
+    protected void onClick() {
+        if (dialogueIndex == 0) {
+            nextDialogue();
+            this.dialog.addDialogOption(OPTIONS[0]).setOptionResult((i)->{
+                character.alreadyPerformedTransaction = true;
+                goToDialogue(2);
+                character.blockingDialogueIndex = 0;
+                CardCrawlGame.sound.play("ATTACK_PIERCING_WAIL", 0f);
+            });
+            this.dialog.addDialogOption(OPTIONS[1]).setOptionResult((i)-> goToDialogue(3));
+        } else if (dialogueIndex >= 2) {
+            endCutscene();
+        } else {
+            nextDialogue();
+        }
+    }
+}

--- a/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressPatron.java
+++ b/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressPatron.java
@@ -1,0 +1,80 @@
+package spireCafe.interactables.patrons.packmistress;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.math.MathUtils;
+import com.esotericsoftware.spine.*;
+import com.evacipated.cardcrawl.modthespire.Loader;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.localization.CharacterStrings;
+import spireCafe.Anniv7Mod;
+import spireCafe.abstracts.AbstractPatron;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class PackmistressPatron extends AbstractPatron {
+    public static final String ID = PackmistressPatron.class.getSimpleName();
+    private static final CharacterStrings characterStrings = CardCrawlGame.languagePack.getCharacterString(Anniv7Mod.makeID(ID));
+
+    private static Class<?> packmistressSkin;
+    private static Class<?> abstractSkin;
+
+    public PackmistressPatron(float animationX, float animationY) {
+        super(animationX, animationY, 160.0f, 200.0f);
+        this.name = characterStrings.NAMES[0];
+        this.authors = "modargo";
+
+        Object skin = null;
+        String jsonPath = null;
+        String atlasPath = null;
+        if (Loader.isModLoaded("anniv5")) {
+            try {
+                packmistressSkin = Class.forName("thePackmaster.skins.instances.PackmistressSkin");
+                abstractSkin = Class.forName("thePackmaster.skins.AbstractSkin");
+                Constructor<?> constructor = packmistressSkin.getDeclaredConstructor();
+                constructor.setAccessible(true);
+                skin = constructor.newInstance();
+                Method m1 = abstractSkin.getDeclaredMethod("getSkeletonJSONPath");
+                Method m2 = abstractSkin.getDeclaredMethod("getSkeletonAtlasPath");
+                jsonPath = (String)m1.invoke(skin);
+                atlasPath = (String)m2.invoke(skin);
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                e.printStackTrace();
+                throw new RuntimeException("Error retrieving classes from Packmaster", e);
+            }
+        }
+
+        this.atlas = new TextureAtlas(Gdx.files.internal(atlasPath));
+        SkeletonJson json = new SkeletonJson(this.atlas);
+        json.setScale(Settings.renderScale);
+        SkeletonData skeletonData = json.readSkeletonData(Gdx.files.internal(jsonPath));
+        this.skeleton = new Skeleton(skeletonData);
+        this.skeleton.setColor(Color.WHITE);
+        this.stateData = new AnimationStateData(skeletonData);
+        this.state = new AnimationState(this.stateData);
+        AnimationState.TrackEntry e = this.state.setAnimation(0, "Idle", true);
+        e.setTime(e.getEndTime() * MathUtils.random());
+
+    }
+
+    @Override
+    public boolean canSpawn() {
+        return Loader.isModLoaded("anniv5");
+    }
+
+    public void setCutscenePortrait(String texture) {
+    }
+
+    public void renderCutscenePortrait(SpriteBatch sb) {
+    }
+
+    public void onInteract() {
+        AbstractDungeon.topLevelEffectsQueue.add(new PackmistressCutscene(this));
+    }
+}

--- a/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Characterstrings.json
@@ -1,0 +1,9 @@
+{
+  "${ModID}:PackmistressPatron": {
+    "NAMES": [
+      "Packmistress"
+    ],
+    "TEXT": [
+    ]
+  }
+}

--- a/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Cutscenestrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Cutscenestrings.json
@@ -2,17 +2,19 @@
   "${ModID}:PackmistressCutscene": {
     "NAME": "Packmistress Cutscene",
     "BLOCKING_TEXTS": [
-      "TODO"
+      "\"Good luck out there.\""
     ],
     "DESCRIPTIONS": [
-      "TODO",
-      "TODO",
-      "TODO",
-      "TODO"
+      "\"Hi there! Nice to see the café bustling, isn't it? I'm taking a quick rest, this backpack is really heavy you know.\"",
+      "\"Say, could I interest you in some of the junk I've got in here? I'll be fine without it and it would cut down on how much this thing weighs. And for some reason I'm carrying around all these bags and boxes....\"",
+      "After rummaging around for a bit, the Packmistress pulls out what looks like a well-worn sack and a big box, indicating that they're both for trade. NL NL \"Café regulations require a fair price, so I'll have to charge you for these!\"",
+      "\"Thanks, my pack feels lighter now! Hope you can make good use of that.\"",
+      "You politely decline."
     ],
     "OPTIONS": [
-      "TODO",
-      "TODO"
+      "[Sack] #gObtain {0}. #rLose #r{1} #rMax #rHP.",
+      "[Box] #gObtain {0}. #rBecome #rCursed #r- #rClumsy.",
+      "[Decline]"
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Cutscenestrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Cutscenestrings.json
@@ -1,0 +1,18 @@
+{
+  "${ModID}:PackmistressCutscene": {
+    "NAME": "Packmistress Cutscene",
+    "BLOCKING_TEXTS": [
+      "TODO"
+    ],
+    "DESCRIPTIONS": [
+      "TODO",
+      "TODO",
+      "TODO",
+      "TODO"
+    ],
+    "OPTIONS": [
+      "TODO",
+      "TODO"
+    ]
+  }
+}


### PR DESCRIPTION
I wanted a Packmaster reference that was simple and straightforward, so the Packmistress patron lets you get two specific Packmaster relics in exchange for max HP or a curse. Both the relics are quite good, so the costs are intended to be a fair exchange (overall positive for the player but taking on some risk due to lower max HP or a curse in the deck).

This only shows up if you have Packmaster on and directly uses the Packmistress model (through the magic of reflection to avoid dependencies), thus there are no new images required. I deliberately avoided adding any logic like "don't show up if the player is Packmaster/Packmistress" because I think it's funny to let people see their doppelganger in the cafe (and the relics should work just fine if the player gets multiple copies).

Screenshots:
![image](https://github.com/user-attachments/assets/b0631d18-dd91-48fd-aa0f-55ab06fda463)
![image](https://github.com/user-attachments/assets/4c184f86-8536-4735-9e92-898062367515)
