### PR TITLE
Packmaster merchant

### DIFF
--- a/src/main/java/spireCafe/abstracts/AbstractMerchant.java
+++ b/src/main/java/spireCafe/abstracts/AbstractMerchant.java
@@ -71,6 +71,9 @@ public abstract class AbstractMerchant extends AbstractCafeInteractable {
 
     public void renderShop(SpriteBatch sb) {
         sb.setColor(Color.WHITE);
+        if (background == null) {
+            throw new RuntimeException("Missing background for merchant");
+        }
         sb.draw(background, 0f,0f, Settings.WIDTH, Settings.HEIGHT);
         for (AbstractArticle article : articles) {
             article.render(sb);

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -160,7 +160,7 @@ public class PackmasterMerchant extends AbstractMerchant {
     private String getRandomMessage() {
         String[] s = packmasterStrings.TEXT;
         ArrayList<String> possibleMessages = new ArrayList<>();
-        int baseMessageCount = 5;
+        int baseMessageCount = 6;
         for (int i = 0; i < baseMessageCount; i++) {
             possibleMessages.add(s[i]);
         }

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -43,6 +43,8 @@ public class PackmasterMerchant extends AbstractMerchant {
     private static Class<?> anniv5;
     private static Class<?> abstractCardPack;
 
+    private float speechTimer = 0.0f;
+
     public PackmasterMerchant(float animationX, float animationY) {
         super(animationX, animationY, 360.0f, 235.0f);
         this.name = packmasterStrings.NAMES[0];
@@ -92,6 +94,7 @@ public class PackmasterMerchant extends AbstractMerchant {
     @Override
     public void onInteract() {
         super.onInteract();
+        this.speechTimer = MathUtils.random(5.0f, 10.0f);
     }
 
     @Override
@@ -118,6 +121,17 @@ public class PackmasterMerchant extends AbstractMerchant {
             AbstractCard card = cards.get(i);
             int price = (int)(AbstractCard.getPrice(card.rarity) * AbstractDungeon.miscRng.random(0.9f, 1.1f));
             articles.add(new CardArticle(card.cardID, this, xPos, yPos, card, price));
+        }
+    }
+
+    @Override
+    public void updateShop() {
+        super.updateShop();
+        this.speechTimer -= Gdx.graphics.getDeltaTime();
+        if (this.speechBubble == null && this.speechTimer <= 0.0f) {
+            this.speechTimer = MathUtils.random(40.0f, 60.0f);
+            String message = packmasterStrings.TEXT[MathUtils.random(4)];
+            this.createSpeechBubble(message);
         }
     }
 

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -48,23 +48,22 @@ public class PackmasterMerchant extends AbstractMerchant {
                 Method m2 = abstractSkin.getDeclaredMethod("getSkeletonAtlasPath");
                 jsonPath = (String)m1.invoke(skin);
                 atlasPath = (String)m2.invoke(skin);
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
-                     InvocationTargetException | NoSuchMethodException e) {
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 e.printStackTrace();
                 throw new RuntimeException("Error retrieving classes from Packmaster", e);
             }
-        }
 
-        this.atlas = new TextureAtlas(Gdx.files.internal(atlasPath));
-        SkeletonJson json = new SkeletonJson(this.atlas);
-        json.setScale(Settings.renderScale);
-        SkeletonData skeletonData = json.readSkeletonData(Gdx.files.internal(jsonPath));
-        this.skeleton = new Skeleton(skeletonData);
-        this.skeleton.setColor(Color.WHITE);
-        this.stateData = new AnimationStateData(skeletonData);
-        this.state = new AnimationState(this.stateData);
-        AnimationState.TrackEntry e = this.state.setAnimation(0, "Idle", true);
-        e.setTime(e.getEndTime() * MathUtils.random());
+            this.atlas = new TextureAtlas(Gdx.files.internal(atlasPath));
+            SkeletonJson json = new SkeletonJson(this.atlas);
+            json.setScale(Settings.renderScale);
+            SkeletonData skeletonData = json.readSkeletonData(Gdx.files.internal(jsonPath));
+            this.skeleton = new Skeleton(skeletonData);
+            this.skeleton.setColor(Color.WHITE);
+            this.stateData = new AnimationStateData(skeletonData);
+            this.state = new AnimationState(this.stateData);
+            AnimationState.TrackEntry e = this.state.setAnimation(0, "Idle", true);
+            e.setTime(e.getEndTime() * MathUtils.random());
+        }
     }
 
     @Override

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -1,0 +1,87 @@
+package spireCafe.interactables.merchants.packmaster;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.MathUtils;
+import com.esotericsoftware.spine.*;
+import com.evacipated.cardcrawl.modthespire.Loader;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.localization.CharacterStrings;
+import spireCafe.Anniv7Mod;
+import spireCafe.abstracts.AbstractMerchant;
+import spireCafe.vfx.TopLevelSpeechEffect;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class PackmasterMerchant extends AbstractMerchant {
+    public static final String ID = PackmasterMerchant.class.getSimpleName();
+    public static final CharacterStrings packmasterStrings = CardCrawlGame.languagePack.getCharacterString(Anniv7Mod.makeID(ID));
+    private static final Texture BG_TEXTURE = ImageMaster.loadImage("images/npcs/rug/eng.png");
+
+    private static Class<?> packmasterSkin;
+    private static Class<?> abstractSkin;
+
+    public PackmasterMerchant(float animationX, float animationY) {
+        super(animationX, animationY, 360.0f, 235.0f);
+        this.name = packmasterStrings.NAMES[0];
+        this.authors = "modargo";
+        this.background = new TextureRegion(BG_TEXTURE);
+
+        Object skin = null;
+        String jsonPath = null;
+        String atlasPath = null;
+        if (Loader.isModLoaded("anniv5")) {
+            try {
+                packmasterSkin = Class.forName("thePackmaster.skins.instances.PackmasterSkin");
+                abstractSkin = Class.forName("thePackmaster.skins.AbstractSkin");
+                Constructor<?> constructor = packmasterSkin.getDeclaredConstructor();
+                constructor.setAccessible(true);
+                skin = constructor.newInstance();
+                Method m1 = abstractSkin.getDeclaredMethod("getSkeletonJSONPath");
+                Method m2 = abstractSkin.getDeclaredMethod("getSkeletonAtlasPath");
+                jsonPath = (String)m1.invoke(skin);
+                atlasPath = (String)m2.invoke(skin);
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
+                     InvocationTargetException | NoSuchMethodException e) {
+                e.printStackTrace();
+                throw new RuntimeException("Error retrieving classes from Packmaster", e);
+            }
+        }
+
+        this.atlas = new TextureAtlas(Gdx.files.internal(atlasPath));
+        SkeletonJson json = new SkeletonJson(this.atlas);
+        json.setScale(Settings.renderScale);
+        SkeletonData skeletonData = json.readSkeletonData(Gdx.files.internal(jsonPath));
+        this.skeleton = new Skeleton(skeletonData);
+        this.skeleton.setColor(Color.WHITE);
+        this.stateData = new AnimationStateData(skeletonData);
+        this.state = new AnimationState(this.stateData);
+        AnimationState.TrackEntry e = this.state.setAnimation(0, "Idle", true);
+        e.setTime(e.getEndTime() * MathUtils.random());
+    }
+
+    @Override
+    public boolean canSpawn() {
+        return Loader.isModLoaded("anniv5");
+    }
+
+    @Override
+    public void onInteract() {
+        super.onInteract();
+    }
+
+    @Override
+    public void rollShop() {
+    }
+
+    @Override
+    public void onCloseShop() {
+    }
+}

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -8,6 +8,8 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.MathUtils;
 import com.esotericsoftware.spine.*;
+import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.OnObtainCard;
+import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.StartupCard;
 import com.evacipated.cardcrawl.modthespire.Loader;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -145,6 +147,22 @@ public class PackmasterMerchant extends AbstractMerchant {
                     cards.add(CardLibrary.getCard("anniv5:" + id));
                 }
                 break;
+            case Ethereal:
+                List<AbstractCard> ethereal = this.getOneCardPerPack(allPacks, c -> c.isEthereal);
+                cards.addAll(ethereal);
+                break;
+            case Startup:
+                List<AbstractCard> startup = this.getOneCardPerPack(allPacks, c -> c.isInnate || c instanceof StartupCard || c instanceof OnObtainCard);
+                cards.addAll(startup);
+                break;
+            case ZeroCost:
+                List<AbstractCard> zeroCost = this.getOneCardPerPack(allPacks, c -> c.cost == 0);
+                cards.addAll(zeroCost);
+                break;
+            case XCost:
+                List<AbstractCard> xCost = this.getOneCardPerPack(allPacks, c -> c.cost == -1);
+                cards.addAll(xCost);
+                break;
         }
 
         int tmp = (int)(Settings.WIDTH - DRAW_START_X * 2.0F - AbstractCard.IMG_WIDTH_S * 5.0F) / 4;
@@ -159,21 +177,14 @@ public class PackmasterMerchant extends AbstractMerchant {
     }
 
     private ShopType rollShopType() {
-        List<ShopType> possibleShopTypes;
-        if (AbstractDungeon.miscRng.random(99) < 75) {
-            possibleShopTypes = Arrays.asList(ShopType.OnePack, ShopType.TwoPacks, ShopType.Rares);
-        }
-        else {
-            possibleShopTypes = Arrays.asList(ShopType.Skims, ShopType.Strikes, ShopType.IronWaves, ShopType.Energy);
-        }
-
-        return possibleShopTypes.get(AbstractDungeon.miscRng.random(possibleShopTypes.size() - 1));
+        ShopType[] shopTypes = ShopType.values();
+        return shopTypes[AbstractDungeon.miscRng.random(shopTypes.length - 1)];
     }
 
     private ArrayList<AbstractCard> getOneCardPerPack(ArrayList<Object> allPacks, Function<AbstractCard, Boolean> f) {
         ArrayList<AbstractCard> cards = new ArrayList<>();
         Supplier<Boolean> check = () -> cards.size() < 10;
-        for (int i = 0; check.get() || i < allPacks.size(); i++) {
+        for (int i = 0; check.get() && i < allPacks.size(); i++) {
             List<AbstractCard> validCards = this.getPackCards(allPacks.get(i)).stream().filter(f::apply).collect(Collectors.toList());
             if (validCards.size() == 1) {
                 cards.add(validCards.get(0));
@@ -236,6 +247,10 @@ public class PackmasterMerchant extends AbstractMerchant {
         Skims,
         Strikes,
         IronWaves,
-        Energy
+        Energy,
+        Ethereal,
+        Startup,
+        ZeroCost,
+        XCost
     }
 }

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -1,5 +1,6 @@
 package spireCafe.interactables.merchants.packmaster;
 
+import basemod.ReflectionHacks;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -8,25 +9,39 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.MathUtils;
 import com.esotericsoftware.spine.*;
 import com.evacipated.cardcrawl.modthespire.Loader;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.localization.CharacterStrings;
+import com.megacrit.cardcrawl.random.Random;
 import spireCafe.Anniv7Mod;
 import spireCafe.abstracts.AbstractMerchant;
+import spireCafe.interactables.merchants.CardArticle;
+import spireCafe.interactables.merchants.secretshop.IdentifyCardArticle;
+import spireCafe.interactables.merchants.secretshop.UnidentifiedCard;
 import spireCafe.vfx.TopLevelSpeechEffect;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
 
 public class PackmasterMerchant extends AbstractMerchant {
     public static final String ID = PackmasterMerchant.class.getSimpleName();
     public static final CharacterStrings packmasterStrings = CardCrawlGame.languagePack.getCharacterString(Anniv7Mod.makeID(ID));
     private static final Texture BG_TEXTURE = ImageMaster.loadImage("images/npcs/rug/eng.png");
 
+    private static final float TOP_ROW_Y = 760.0F * Settings.yScale;
+    private static final float BOTTOM_ROW_Y = 337.0F * Settings.yScale;
+    private static final float DRAW_START_X = Settings.WIDTH * 0.16F;
+
     private static Class<?> packmasterSkin;
     private static Class<?> abstractSkin;
+    private static Class<?> anniv5;
+    private static Class<?> abstractCardPack;
 
     public PackmasterMerchant(float animationX, float animationY) {
         super(animationX, animationY, 360.0f, 235.0f);
@@ -48,6 +63,9 @@ public class PackmasterMerchant extends AbstractMerchant {
                 Method m2 = abstractSkin.getDeclaredMethod("getSkeletonAtlasPath");
                 jsonPath = (String)m1.invoke(skin);
                 atlasPath = (String)m2.invoke(skin);
+
+                anniv5 = Class.forName("thePackmaster.SpireAnniversary5Mod");
+                abstractCardPack = Class.forName("thePackmaster.packs.AbstractCardPack");
             } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 e.printStackTrace();
                 throw new RuntimeException("Error retrieving classes from Packmaster", e);
@@ -78,6 +96,29 @@ public class PackmasterMerchant extends AbstractMerchant {
 
     @Override
     public void rollShop() {
+        ArrayList<Object> allPacks = new ArrayList<>(ReflectionHacks.getPrivateStatic(anniv5, "allPacks"));
+        Collections.shuffle(allPacks, new java.util.Random(AbstractDungeon.miscRng.randomLong()));
+        Object pack = allPacks.get(0);
+        ArrayList<AbstractCard> cards = new ArrayList<>();
+        try {
+            for (AbstractCard card : (ArrayList<AbstractCard>)ReflectionHacks.getCachedField(abstractCardPack, "cards").get(pack)) {
+                if (card.rarity == AbstractCard.CardRarity.COMMON || card.rarity == AbstractCard.CardRarity.UNCOMMON || card.rarity == AbstractCard.CardRarity.RARE) {
+                    cards.add(card);
+                }
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        int tmp = (int)(Settings.WIDTH - DRAW_START_X * 2.0F - AbstractCard.IMG_WIDTH_S * 5.0F) / 4;
+        float padX = (int)(tmp + AbstractCard.IMG_WIDTH_S) + 10.0F * Settings.scale;
+        for (int i = 0; i < 10; i++) {
+            float xPos = DRAW_START_X + AbstractCard.IMG_WIDTH_S / 2.0F + padX * (i % 5);
+            float yPos = i < 5 ? TOP_ROW_Y : BOTTOM_ROW_Y;
+            AbstractCard card = cards.get(i);
+            int price = (int)(AbstractCard.getPrice(card.rarity) * AbstractDungeon.miscRng.random(0.9f, 1.1f));
+            articles.add(new CardArticle(card.cardID, this, xPos, yPos, card, price));
+        }
     }
 
     @Override

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -43,8 +43,6 @@ public class PackmasterMerchant extends AbstractMerchant {
     private static final float BOTTOM_ROW_Y = 337.0F * Settings.yScale;
     private static final float DRAW_START_X = Settings.WIDTH * 0.16F;
 
-    private static Class<?> packmasterSkin;
-    private static Class<?> abstractSkin;
     private static Class<?> anniv5;
     private static Class<?> abstractCardPack;
 
@@ -62,8 +60,8 @@ public class PackmasterMerchant extends AbstractMerchant {
         String atlasPath = null;
         if (Loader.isModLoaded("anniv5")) {
             try {
-                packmasterSkin = Class.forName("thePackmaster.skins.instances.PackmasterSkin");
-                abstractSkin = Class.forName("thePackmaster.skins.AbstractSkin");
+                Class<?> packmasterSkin = Class.forName("thePackmaster.skins.instances.PackmasterSkin");
+                Class<?> abstractSkin = Class.forName("thePackmaster.skins.AbstractSkin");
                 Constructor<?> constructor = packmasterSkin.getDeclaredConstructor();
                 constructor.setAccessible(true);
                 skin = constructor.newInstance();

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -130,9 +130,22 @@ public class PackmasterMerchant extends AbstractMerchant {
         this.speechTimer -= Gdx.graphics.getDeltaTime();
         if (this.speechBubble == null && this.speechTimer <= 0.0f) {
             this.speechTimer = MathUtils.random(40.0f, 60.0f);
-            String message = packmasterStrings.TEXT[MathUtils.random(4)];
-            this.createSpeechBubble(message);
+            this.createSpeechBubble(this.getRandomMessage());
         }
+    }
+
+    private String getRandomMessage() {
+        String[] s = packmasterStrings.TEXT;
+        ArrayList<String> possibleMessages = new ArrayList<>();
+        int baseMessageCount = 5;
+        for (int i = 0; i < baseMessageCount; i++) {
+            possibleMessages.add(s[i]);
+        }
+        if (AbstractDungeon.player.chosenClass.toString().equals("THE_PACKMASTER")) {
+            possibleMessages.add(s[5]);
+        }
+
+        return possibleMessages.get(MathUtils.random(possibleMessages.size() - 1));
     }
 
     @Override

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.esotericsoftware.spine.*;
 import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.OnObtainCard;
 import com.evacipated.cardcrawl.mod.stslib.cards.interfaces.StartupCard;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.ExhaustiveField;
 import com.evacipated.cardcrawl.modthespire.Loader;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -163,6 +164,10 @@ public class PackmasterMerchant extends AbstractMerchant {
                 List<AbstractCard> xCost = this.getOneCardPerPack(allPacks, c -> c.cost == -1);
                 cards.addAll(xCost);
                 break;
+            case Exhaust:
+                List<AbstractCard> exhaust = this.getOneCardPerPack(allPacks, c -> c.exhaust || ExhaustiveField.ExhaustiveFields.baseExhaustive.get(c) > 0);
+                cards.addAll(exhaust);
+                break;
         }
 
         int tmp = (int)(Settings.WIDTH - DRAW_START_X * 2.0F - AbstractCard.IMG_WIDTH_S * 5.0F) / 4;
@@ -251,6 +256,7 @@ public class PackmasterMerchant extends AbstractMerchant {
         Ethereal,
         Startup,
         ZeroCost,
-        XCost
+        XCost,
+        Exhaust
     }
 }

--- a/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
+++ b/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
@@ -2,7 +2,6 @@ package spireCafe.interactables.patrons.packmistress;
 
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.curses.Clumsy;
-import com.megacrit.cardcrawl.cards.curses.Writhe;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.RelicLibrary;

--- a/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
+++ b/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressCutscene.java
@@ -39,19 +39,20 @@ public class PackmistressCutscene extends AbstractCutscene {
         }
         else if (dialogueIndex == 1) {
             nextDialogue();
+            int completeDialogue = AbstractDungeon.player.chosenClass.toString().equals("THE_PACKMASTER") ? 4 : 3;
             this.dialog.addDialogOption(OPTIONS[0].replace("{0}", this.relic1.name).replace("{1}", this.maxHp + ""), this.relic1).setOptionResult((i)->{
                 AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2), this.relic1);
                 AbstractDungeon.player.decreaseMaxHealth(this.maxHp);
                 character.alreadyPerformedTransaction = true;
-                goToDialogue(3);
+                goToDialogue(completeDialogue);
             });
             this.dialog.addDialogOption(OPTIONS[1].replace("{0}", this.relic2.name), this.relic2).setOptionResult((i)->{
                 AbstractDungeon.getCurrRoom().spawnRelicAndObtain((float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2), this.relic2);
                 AbstractDungeon.effectList.add(new ShowCardAndObtainEffect(this.curse, (float)(Settings.WIDTH / 2), (float)(Settings.HEIGHT / 2)));
                 character.alreadyPerformedTransaction = true;
-                goToDialogue(3);
+                goToDialogue(completeDialogue);
             });
-            this.dialog.addDialogOption(OPTIONS[2]).setOptionResult((i)-> goToDialogue(4));
+            this.dialog.addDialogOption(OPTIONS[2]).setOptionResult((i)-> goToDialogue(5));
         } else if (dialogueIndex >= 2) {
             endCutscene();
         }

--- a/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressPatron.java
+++ b/src/main/java/spireCafe/interactables/patrons/packmistress/PackmistressPatron.java
@@ -22,9 +22,6 @@ public class PackmistressPatron extends AbstractPatron {
     public static final String ID = PackmistressPatron.class.getSimpleName();
     private static final CharacterStrings characterStrings = CardCrawlGame.languagePack.getCharacterString(Anniv7Mod.makeID(ID));
 
-    private static Class<?> packmistressSkin;
-    private static Class<?> abstractSkin;
-
     public PackmistressPatron(float animationX, float animationY) {
         super(animationX, animationY, 160.0f, 200.0f);
         this.name = characterStrings.NAMES[0];
@@ -35,8 +32,8 @@ public class PackmistressPatron extends AbstractPatron {
         String atlasPath = null;
         if (Loader.isModLoaded("anniv5")) {
             try {
-                packmistressSkin = Class.forName("thePackmaster.skins.instances.PackmistressSkin");
-                abstractSkin = Class.forName("thePackmaster.skins.AbstractSkin");
+                Class<?> packmistressSkin = Class.forName("thePackmaster.skins.instances.PackmistressSkin");
+                Class<?> abstractSkin = Class.forName("thePackmaster.skins.AbstractSkin");
                 Constructor<?> constructor = packmistressSkin.getDeclaredConstructor();
                 constructor.setAccessible(true);
                 skin = constructor.newInstance();

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -4,6 +4,11 @@
       "Packmaster"
     ],
     "TEXT": [
+      "You wouldn't believe all the stuff I've got in here.",
+      "There's a pack where every card is a Claw, how awesome is that?",
+      "One day they will make the final pack.",
+      "I've got over a thousand different cards I can sell.",
+      "Cards from the same pack often synergize with each other."
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -9,7 +9,10 @@
       "One day they will make the final pack.",
       "I've got over a thousand different cards I can sell.",
       "Cards from the same pack often synergize with each other.",
-      "Hey, I recognize you."
+      "Hey, I recognize you.",
+      "I've prepared a full spread from this delightful pack, just for you.",
+      "I wonder what you can do by mixing together these two packs?",
+      "I've got a might fine selection of rares for you today."
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -13,7 +13,11 @@
       "Hey, I recognize you.",
       "I've prepared a full spread from this delightful pack, just for you.",
       "I wonder what you can do by mixing together these two packs?",
-      "I've got a might fine selection of rares for you today."
+      "I've got a might fine selection of rares for you today.",
+      "Check out all these Skims.",
+      "This is a very striking shop.",
+      "Ended up with too many iron waves in my pack, want to take some off my hands?",
+      "Enough energy to power a whole country."
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -17,7 +17,11 @@
       "Check out all these Skims.",
       "This is a very striking shop.",
       "Ended up with too many iron waves in my pack, want to take some off my hands?",
-      "Enough energy to power a whole country."
+      "Enough energy to power a whole country.",
+      "Use these cards before they fade away.",
+      "First turn best turn.",
+      "These cards are free... but they still cost gold. And a card draw.",
+      "Don't you wish you had Chemical X right now?"
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -1,0 +1,9 @@
+{
+  "${ModID}:PackmasterMerchant": {
+    "NAMES": [
+      "Packmaster"
+    ],
+    "TEXT": [
+    ]
+  }
+}

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -9,6 +9,7 @@
       "One day they will make the final pack.",
       "I've got over a thousand different cards I can sell.",
       "Cards from the same pack often synergize with each other.",
+      "Hope you're enjoying the Café!",
       "Hey, I recognize you.",
       "I've prepared a full spread from this delightful pack, just for you.",
       "I wonder what you can do by mixing together these two packs?",

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -8,7 +8,8 @@
       "There's a pack where every card is a Claw, how awesome is that?",
       "One day they will make the final pack.",
       "I've got over a thousand different cards I can sell.",
-      "Cards from the same pack often synergize with each other."
+      "Cards from the same pack often synergize with each other.",
+      "Hey, I recognize you."
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmasterMerchant/Characterstrings.json
@@ -21,7 +21,8 @@
       "Use these cards before they fade away.",
       "First turn best turn.",
       "These cards are free... but they still cost gold. And a card draw.",
-      "Don't you wish you had Chemical X right now?"
+      "Don't you wish you had Chemical X right now?",
+      "One use per fight only! Or sometimes more."
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Cutscenestrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/PackmistressPatron/Cutscenestrings.json
@@ -9,6 +9,7 @@
       "\"Say, could I interest you in some of the junk I've got in here? I'll be fine without it and it would cut down on how much this thing weighs. And for some reason I'm carrying around all these bags and boxes....\"",
       "After rummaging around for a bit, the Packmistress pulls out what looks like a well-worn sack and a big box, indicating that they're both for trade. NL NL \"Café regulations require a fair price, so I'll have to charge you for these!\"",
       "\"Thanks, my pack feels lighter now! Hope you can make good use of that.\"",
+      "\"Thanks, looks like your pack is just as big as mine now!\"",
       "You politely decline."
     ],
     "OPTIONS": [


### PR DESCRIPTION
The Packmaster merchant sells cards from Packmaster, picking from a variety of different shop configurations.
* All cards from one pack
* All cards of one rarity from two packs
* 10 pre-selected Skim-like cards
* 10 pre-selected Iron Wave-like cards
* 10 pre-selected energy generating cards
* One rare each from 10 different packs
* One Strike each from 10 different packs
* One innate/startup/pick card each from 10 different packs
* One ethereal card each from 10 different packs
* One 0-cost card each from 10 different packs
* One X-cost card each from 10 different packs
* One exhaust card each from 10 different packs
The pre-selected shops don't use any cards from the expansion packs, since I didn't want to add extra checks for that. 

For example, here's the Skims shop:
![image](https://github.com/user-attachments/assets/555a71d6-1abc-43ad-acee-5a045413e24c)

In this PR I also added some special text for Packmistress if you're playing as Packmaster.