### PR TITLE
fix: Only do the relic shuffle if the player is glitched

### DIFF
--- a/src/main/java/spireCafe/interactables/patrons/missingno/MissingnoUtil.java
+++ b/src/main/java/spireCafe/interactables/patrons/missingno/MissingnoUtil.java
@@ -220,14 +220,16 @@ public class MissingnoUtil {
 
         if(time > 60f && !hasNameChanged) {
             hasNameChanged = true;
-            if(isGlitched() && Wiz.isInCombat() && miscRng.randomBoolean(.33f)) {
+            if(isGlitched() && miscRng.randomBoolean(.33f)) {
                 AbstractDungeon.topPanel.setPlayerName();
             }
         }
 
         if(time > 80f && !hasShuffledRelics) {
-            MissingnoUtil.shuffleRelics();
             hasShuffledRelics = true;
+            if(isGlitched()) {
+                MissingnoUtil.shuffleRelics();
+            }
         }
 
         if(time > 20f && !hasPlayedSfx) {


### PR DESCRIPTION
Only do the relic shuffle if the player is glitched.
Also you don't need to be in combat to have the name changed, why did I have that in there?
  
### Checklist
- [x] I have added myself to the authors list in the ModTheSpire.json
- [x] I have updated my entry and its state in the [Contribution List](https://docs.google.com/spreadsheets/d/1PgRwGs0OWx8RKYv1QEsrOm7HJdfaqULHRM5qSSHo_yU/edit?usp=sharing)
- [x] I have removed all the placeholder and TODO strings in my contribution