### PR TITLE
Fade-in/fade-out for custom merchants

### DIFF
--- a/src/main/java/spireCafe/abstracts/AbstractMerchant.java
+++ b/src/main/java/spireCafe/abstracts/AbstractMerchant.java
@@ -45,6 +45,7 @@ public abstract class AbstractMerchant extends AbstractCafeInteractable {
     @Override
     public void onInteract() {
         BaseMod.openCustomScreen(CafeMerchantScreen.ScreenEnum.CAFE_MERCHANT_SCREEN, this);
+        AbstractDungeon.overlayMenu.showBlackScreen();
     }
 
     //Override if you need special behavior when an article is bought
@@ -53,7 +54,9 @@ public abstract class AbstractMerchant extends AbstractCafeInteractable {
     }
 
     //Called after the custom screen is close in case you need to take care of lingering effects or something
-    public void onCloseShop() {}
+    public void onCloseShop() {
+        AbstractDungeon.overlayMenu.hideBlackScreen();
+    }
 
     public void updateShop() {
         for (AbstractArticle article : toAdd) {

--- a/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/packmaster/PackmasterMerchant.java
@@ -238,10 +238,6 @@ public class PackmasterMerchant extends AbstractMerchant {
         return possibleMessages.get(MathUtils.random(possibleMessages.size() - 1));
     }
 
-    @Override
-    public void onCloseShop() {
-    }
-
     private enum ShopType {
         OnePack,
         TwoPacks,

--- a/src/main/java/spireCafe/interactables/merchants/snackmaster/SnackmasterMerchant.java
+++ b/src/main/java/spireCafe/interactables/merchants/snackmaster/SnackmasterMerchant.java
@@ -47,6 +47,7 @@ public class SnackmasterMerchant extends AbstractMerchant {
 
     @Override
     public void onCloseShop() {
+        super.onCloseShop();
         speechEffect.duration = -1;
         speechEffect = null;
     }


### PR DESCRIPTION
Right now there is no bg fade-in/fade-out when interacting with a merchant. This will add that so it looks a little neater and like a base game shop.
  
### Checklist
- [X] I have added myself to the authors list in the ModTheSpire.json
- [X] I have updated my entry and its state in the [Contribution List](https://docs.google.com/spreadsheets/d/1PgRwGs0OWx8RKYv1QEsrOm7HJdfaqULHRM5qSSHo_yU/edit?usp=sharing)
- [X] I have removed all the placeholder and TODO strings in my contribution