### PR TITLE
idnetify bug fix

### DIFF
--- a/src/main/java/spireCafe/interactables/merchants/secretshop/IdentifyCardArticle.java
+++ b/src/main/java/spireCafe/interactables/merchants/secretshop/IdentifyCardArticle.java
@@ -26,6 +26,7 @@ public class IdentifyCardArticle extends CardArticle{
         this.identifyArticle = identifyArticle;
         this.unidentifiedCard.hiddenCard = hiddenCard;
         this.ssMerchant = (SecretShopMerchant) merchant;
+        this.unidentifiedCard.identify();
     }
 
     @Override

--- a/src/main/java/spireCafe/interactables/merchants/secretshop/UnidentifiedCard.java
+++ b/src/main/java/spireCafe/interactables/merchants/secretshop/UnidentifiedCard.java
@@ -34,7 +34,6 @@ public class UnidentifiedCard extends AbstractSCCard{
 
     public UnidentifiedCard() {
         super(ID, ZONE, COST, TYPE, RARITY, TARGET);
-        identify();
     }
 
     @Override


### PR DESCRIPTION
I bring a certain "buggy" vibe to production that maintainers don't really like.

Fixed bug where the initial identify wasn't ID'ing the card underneath the Unidentified card.