### PR TITLE
fix: Missingno & Biome Guy Issues

### DIFF
--- a/src/main/java/spireCafe/abstracts/AbstractCafeInteractable.java
+++ b/src/main/java/spireCafe/abstracts/AbstractCafeInteractable.java
@@ -36,7 +36,7 @@ public abstract class AbstractCafeInteractable {
     public boolean flipHorizontal = false;
     public boolean flipVertical = false;
     protected Hitbox hitbox;
-    private boolean showTooltip = false;
+    protected boolean showTooltip = false;
 
     public float animationX;
     public float animationY;

--- a/src/main/java/spireCafe/actions/MoveCardToDeckAction.java
+++ b/src/main/java/spireCafe/actions/MoveCardToDeckAction.java
@@ -12,7 +12,7 @@ public class MoveCardToDeckAction extends AbstractGameAction {
     }
     @Override
     public void update() {
-        AbstractDungeon.player.hand.moveToDeck(card, true);
+        AbstractDungeon.player.hand.moveToDeck(card, false);
         isDone = true;
     }
 }

--- a/src/main/java/spireCafe/interactables/patrons/missingno/MissingnoPatron.java
+++ b/src/main/java/spireCafe/interactables/patrons/missingno/MissingnoPatron.java
@@ -9,7 +9,9 @@ import com.badlogic.gdx.math.MathUtils;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.localization.CharacterStrings;
+import com.megacrit.cardcrawl.localization.UIStrings;
 import spireCafe.Anniv7Mod;
 import spireCafe.abstracts.AbstractPatron;
 import spireCafe.util.TexLoader;
@@ -23,6 +25,8 @@ public class MissingnoPatron extends AbstractPatron {
     public static final String ID = MissingnoPatron.class.getSimpleName();
     public static final String assetID = "MissingnoRelic";
     private static final CharacterStrings characterStrings = CardCrawlGame.languagePack.getCharacterString(Anniv7Mod.makeID(ID));
+    private static final UIStrings authorsString = CardCrawlGame.languagePack.getUIString(makeID("Authors"));
+
     private static ShaderProgram glitchShader = null;
     private final float WAVY_DISTANCE = 2.0F * Settings.scale;
     private float wavy_y;
@@ -50,8 +54,8 @@ public class MissingnoPatron extends AbstractPatron {
         if(shouldShowSpeechBubble) {
             this.speechBubble.render(sb);
         }
+        sb.setColor(Color.WHITE);
         if(!Anniv7Mod.getDisableShadersConfig()) {
-            sb.setColor(Color.WHITE);
             glitchShader = initGlitchShader(glitchShader);
             sb.setShader(glitchShader);
             glitchShader.setUniformf("u_time", (time % 10) + 200);
@@ -66,6 +70,16 @@ public class MissingnoPatron extends AbstractPatron {
             sb.setShader(null);
         }
         this.hitbox.render(sb);
+
+        if(showTooltip && !AbstractDungeon.isScreenUp){
+            String tooltipBody = authorsString.TEXT[0] + this.authors;
+            float boxWidth = 320.0F * Settings.scale;
+
+            float tooltipX = Settings.WIDTH - boxWidth - 20.0f * Settings.scale;
+            float tooltipY = 0.85f * Settings.HEIGHT - 20.0f * Settings.scale;
+
+            TipHelper.renderGenericTip(tooltipX, tooltipY, name, tooltipBody);
+        }
     }
 
 

--- a/src/main/java/spireCafe/interactables/patrons/spiomesmanifestation/SpiomesManifestationPatron.java
+++ b/src/main/java/spireCafe/interactables/patrons/spiomesmanifestation/SpiomesManifestationPatron.java
@@ -11,7 +11,9 @@ import com.evacipated.cardcrawl.modthespire.Loader;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.TipHelper;
 import com.megacrit.cardcrawl.localization.CharacterStrings;
+import com.megacrit.cardcrawl.localization.UIStrings;
 import spireCafe.Anniv7Mod;
 import spireCafe.abstracts.AbstractPatron;
 import spireCafe.util.TexLoader;
@@ -29,6 +31,8 @@ import static spireCafe.interactables.patrons.missingno.MissingnoUtil.initGlitch
 public class SpiomesManifestationPatron extends AbstractPatron {
     public static final String ID = SpiomesManifestationPatron.class.getSimpleName();
     private static final CharacterStrings characterStrings = CardCrawlGame.languagePack.getCharacterString(Anniv7Mod.makeID(ID));
+    private static final UIStrings authorsString = CardCrawlGame.languagePack.getUIString(makeID("Authors"));
+
 
     private static ShaderProgram glitchShader = null;
     private float wavy_y;
@@ -169,11 +173,11 @@ public class SpiomesManifestationPatron extends AbstractPatron {
         if(shouldShowSpeechBubble) {
             this.speechBubble.render(sb);
         }
+        sb.setColor(Color.WHITE);
         if(!Anniv7Mod.getDisableShadersConfig()) {
-            sb.setColor(Color.WHITE);
             glitchShader = initGlitchShader(glitchShader);
             sb.setShader(glitchShader);
-            glitchShader.setUniformf("u_time", (time % 10) + 200);
+            glitchShader.setUniformf("u_time", (time % 10) + 150);
             glitchShader.setUniformf("u_shake_power", 0.010f);
             glitchShader.setUniformf("u_shake_rate", shake_rate.get());
             glitchShader.setUniformf("u_shake_speed", shake_speed.get());
@@ -185,6 +189,16 @@ public class SpiomesManifestationPatron extends AbstractPatron {
             sb.setShader(null);
         }
         this.hitbox.render(sb);
+
+        if(showTooltip && !AbstractDungeon.isScreenUp){
+            String tooltipBody = authorsString.TEXT[0] + this.authors;
+            float boxWidth = 320.0F * Settings.scale;
+
+            float tooltipX = Settings.WIDTH - boxWidth - 20.0f * Settings.scale;
+            float tooltipY = 0.85f * Settings.HEIGHT - 20.0f * Settings.scale;
+
+            TipHelper.renderGenericTip(tooltipX, tooltipY, name, tooltipBody);
+        }
     }
     @Override
     public void update() {


### PR DESCRIPTION
### Description
Fixes:

- Author now shows up on hover of Missingno and Biomes guy
- Missingno and Biome guy are no longer halfway transparent when shaders are off and not hovered over

Changes:

- The random dribble of a card now puts it back on the top of the draw pile instead of a random location

  
### Checklist
- [x] I have added myself to the authors list in the ModTheSpire.json
- [x] I have updated my entry and its state in the [Contribution List](https://docs.google.com/spreadsheets/d/1PgRwGs0OWx8RKYv1QEsrOm7HJdfaqULHRM5qSSHo_yU/edit?usp=sharing)
- [x] I have removed all the placeholder and TODO strings in my contribution