### PR TITLE
Three bug fixes and clarifications

### DIFF
--- a/src/main/java/spireCafe/cardmods/AutoplayMod.java
+++ b/src/main/java/spireCafe/cardmods/AutoplayMod.java
@@ -1,6 +1,7 @@
 package spireCafe.cardmods;
 
 import basemod.abstracts.AbstractCardModifier;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.utility.NewQueueCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -19,7 +20,15 @@ public class AutoplayMod extends AbstractCardModifier {
 
     @Override
     public void onDrawn(AbstractCard card) {
-        AbstractDungeon.actionManager.addToBottom(new NewQueueCardAction(card, AbstractDungeon.getCurrRoom().monsters.getRandomMonster(null, true, AbstractDungeon.cardRandomRng)));
+        AbstractDungeon.actionManager.addToBottom(new AbstractGameAction() {
+            @Override
+            public void update() {
+                if (AbstractDungeon.player.hand.contains(card)) {
+                    AbstractDungeon.actionManager.addToTop(new NewQueueCardAction(card, AbstractDungeon.getCurrRoom().monsters.getRandomMonster(null, true, AbstractDungeon.cardRandomRng)));
+                }
+                this.isDone = true;
+            }
+        });
     }
 
     @Override

--- a/src/main/java/spireCafe/interactables/patrons/dandadan/RightballPotion.java
+++ b/src/main/java/spireCafe/interactables/patrons/dandadan/RightballPotion.java
@@ -18,6 +18,7 @@ public class RightballPotion extends CustomPotion implements CustomSavable<Integ
     public static final String Potion_ID = Anniv7Mod.makeID(RightballPotion.class.getSimpleName());
 
     private static final PotionStrings potionStrings;
+    private static final int RETURN_CHANCE_REDUCTION = 10;
     public int returnChance;
 
     public RightballPotion(int returnChance) {
@@ -37,7 +38,7 @@ public class RightballPotion extends CustomPotion implements CustomSavable<Integ
 
     public void initializeData() {
         this.potency = this.getPotency();
-        this.description = String.format(potionStrings.DESCRIPTIONS[0], potency, returnChance);
+        this.description = String.format(potionStrings.DESCRIPTIONS[0], potency, returnChance, RETURN_CHANCE_REDUCTION);
         this.tips.clear();
         this.tips.add(new PowerTip(this.name, this.description));
     }
@@ -49,7 +50,7 @@ public class RightballPotion extends CustomPotion implements CustomSavable<Integ
         this.addToBot(new DamageAction(target, info, AbstractGameAction.AttackEffect.BLUNT_HEAVY));
         if (AbstractDungeon.cardRandomRng.randomBoolean(returnChance / 100.0f)) {
             RightballPotionPatch.rbp = this;
-            returnChance -= 10;
+            returnChance -= RETURN_CHANCE_REDUCTION;
             initializeData();
         } else {
             RightballPotionPatch.rbp = null;

--- a/src/main/resources/anniv7Resources/localization/eng/DandadanPatron/Potionstrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/DandadanPatron/Potionstrings.json
@@ -2,7 +2,7 @@
   "${ModID}:RightballPotion": {
     "NAME": "Golden Fury",
     "DESCRIPTIONS": [
-      "Deal #b%d damage. #b%d%% chance to return after combat."
+      "Deal #b%d damage. #b%d%% chance to return after combat. (Goes down by #b%d%% each use.)"
     ]
   }
 }

--- a/src/main/resources/anniv7Resources/localization/eng/ShrineOfOrderAttraction/Cutscenestrings.json
+++ b/src/main/resources/anniv7Resources/localization/eng/ShrineOfOrderAttraction/Cutscenestrings.json
@@ -13,12 +13,12 @@
     "OPTIONS": [
       "Pick up the disc.",
       "Cracked slot. ",
-      "(Your Common cards copy another of your Commons.)",
+      "(ALL your Common cards copy one of your Commons.)",
       "Leave.",
       "Plain slot. ",
-      "(Your Uncommon cards copy another of your Uncommons.)",
+      "(ALL your Uncommon cards copy one of your Uncommons.)",
       "Embellished slot. ",
-      "(Your Rare cards copy another of your Rares.)",
+      "(ALL your Rare cards copy one of your Rares.)",
       "Shatter. ",
       "(Pick a Basic card. It copies one of your Commons.)",
       "Pick a Basic Card."


### PR DESCRIPTION
* Koishi patron: change Autoplay to not play the card if it's no longer in the player's hand (e.g. if it was discarded to Gambling Chip)
* Dandadan patron: clarify that Right Ball potion's chance of returning goes by each use
* Shrine of Order attraction: clarify that ALL of your cards of a given rarity will copy one of your cards of that rarity